### PR TITLE
automatically calculate sampling rate

### DIFF
--- a/src/main/java/perf/benchmark/RunIndexBuilder.java
+++ b/src/main/java/perf/benchmark/RunIndexBuilder.java
@@ -198,7 +198,6 @@ public class RunIndexBuilder {
 				+ "/etc/hadoop/core-site.xml");
 		
 		// If the input sampingRate = 0.0 (unspecified), then calculate it automatically
-		System.out.println("####: " + samplingRate);
 		if (samplingRate == 0.0){
 			samplingRate = calculateSampingRate(inputsDir);
 			System.out.println("The input samplingRate = 0.0, we set it to " + samplingRate);


### PR DESCRIPTION
Solve Issue #2 

If the sampling rate is set to 0.0, then we will set the sampling rate to 1GB/ totalFileSize. Otherwise, use the specified sampling rate. 
